### PR TITLE
feat: initialize dart travel app

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["next/core-web-vitals", "eslint:recommended"],
+  "rules": {}
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Dart Travel
+
+A stylish Next.js app where users throw a virtual dart at a 3D globe and get a travel plan based on the landing spot and their budget.
+
+## Features
+- Interactive 3D globe using Three.js and React Three Fiber
+- Tailwind CSS styling
+- API route that builds a simple itinerary using reverse geocoding and country info
+
+## Development
+1. Install dependencies: `npm install`
+2. Run the dev server: `npm run dev`
+3. Lint: `npm run lint`
+4. Test (none included): `npm test`

--- a/app/api/plan/route.ts
+++ b/app/api/plan/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+
+interface RequestBody {
+  lat: number;
+  lng: number;
+  budget: number;
+}
+
+export async function POST(req: NextRequest) {
+  const { lat, lng, budget } = (await req.json()) as RequestBody;
+
+  const geoRes = await fetch(
+    `https://api.bigdatacloud.net/data/reverse-geocode-client?latitude=${lat}&longitude=${lng}&localityLanguage=en`
+  );
+  const geo = await geoRes.json();
+  const country = geo.countryName;
+
+  const infoRes = await fetch(
+    `https://restcountries.com/v3.1/name/${encodeURIComponent(country)}?fields=capital`
+  );
+  const info = await infoRes.json();
+  const capital = info[0]?.capital?.[0] || "the capital";
+
+  const days = budget > 2000
+    ? [
+        `Arrive in ${capital} and enjoy premium accommodation.`,
+        `Explore famous sites around ${capital} with a private guide.`,
+        `Take a day trip to a nearby attraction.`,
+        `Relax at a top-rated restaurant.`,
+        `Finish with a cultural experience unique to ${country}.`,
+      ]
+    : [
+        `Fly into ${capital} and check into a budget-friendly stay.`,
+        `Visit free museums and walking tours in ${capital}.`,
+        `Sample local street food and markets.`,
+      ];
+
+  return NextResponse.json({ country, days });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,11 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #__next {
+  height: 100%;
+}
+
+body {
+  @apply bg-gradient-to-br from-sky-100 to-indigo-200;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import "./globals.css";
+import type { ReactNode } from "react";
+
+export const metadata = {
+  title: "Dart Travel",
+  description: "Throw a dart at the globe and plan your trip",
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useState } from "react";
+import Globe from "@/components/Globe";
+
+interface Plan { days: string[] }
+
+export default function Home() {
+  const [budget, setBudget] = useState("");
+  const [location, setLocation] = useState<{ lat: number; lng: number } | null>(null);
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleSelect = (lat: number, lng: number) => {
+    setLocation({ lat, lng });
+  };
+
+  const generatePlan = async () => {
+    if (!location) return;
+    setLoading(true);
+    try {
+      const res = await fetch("/api/plan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ...location, budget: Number(budget) }),
+      });
+      const data = await res.json();
+      setPlan(data);
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <main className="flex flex-col items-center justify-center gap-4 p-4">
+      <h1 className="text-3xl font-bold">Dart Travel</h1>
+      <Globe onSelect={handleSelect} />
+      <input
+        type="number"
+        placeholder="Budget in USD"
+        value={budget}
+        onChange={(e) => setBudget(e.target.value)}
+        className="border rounded p-2"
+      />
+      <button
+        onClick={generatePlan}
+        className="bg-blue-600 text-white px-4 py-2 rounded disabled:opacity-50"
+        disabled={!budget || !location || loading}
+      >
+        {loading ? "Planning..." : "Generate Plan"}
+      </button>
+      {plan && (
+        <div className="mt-4 w-full max-w-md bg-white/70 p-4 rounded shadow">
+          <h2 className="font-semibold mb-2">Suggested itinerary</h2>
+          <ul className="list-disc pl-5">
+            {plan.days.map((d, i) => (
+              <li key={i}>{d}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/components/Globe.tsx
+++ b/components/Globe.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { Canvas, useLoader } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { TextureLoader } from "three";
+import { useCallback } from "react";
+
+function Earth({ onSelect }: { onSelect: (lat: number, lng: number) => void }) {
+  const texture = useLoader(
+    TextureLoader,
+    "https://unpkg.com/three-globe/example/img/earth-blue-marble.jpg"
+  );
+
+  const handleClick = useCallback(
+    (e: any) => {
+      e.stopPropagation();
+      const { point } = e;
+      const lat = 90 - (Math.acos(point.y / point.length()) * 180) / Math.PI;
+      const lng = ((Math.atan2(point.x, point.z) * 180) / Math.PI + 180) % 360 - 180;
+      onSelect(lat, lng);
+    },
+    [onSelect]
+  );
+
+  return (
+    <mesh onClick={handleClick}>
+      <sphereGeometry args={[2, 64, 64]} />
+      <meshStandardMaterial map={texture} />
+    </mesh>
+  );
+}
+
+export default function Globe({ onSelect }: { onSelect: (lat: number, lng: number) => void }) {
+  return (
+    <Canvas style={{ height: "400px", width: "400px" }}>
+      <ambientLight intensity={0.6} />
+      <directionalLight position={[5, 3, 5]} />
+      <Earth onSelect={onSelect} />
+      <OrbitControls enableZoom={false} />
+    </Canvas>
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "dart-travel",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "next": "^14.2.3",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.161.0",
+    "@react-three/fiber": "^8.15.10",
+    "@react-three/drei": "^9.105.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.16",
+    "eslint": "^8.56.0",
+    "eslint-config-next": "^14.2.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {"@/*": ["./*"]}
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- build Next.js app scaffold with Tailwind styling
- add 3D globe component using Three.js for dart target selection
- generate travel plan via API using reverse geocoding and country info

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmmirror.com/@react-three%2fdrei)*
- `npm test`
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e29e394832f944f2bc896219307