### PR TITLE
Add interactive globe travel planner with Next.js and three.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "next/core-web-vitals"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+npm-debug.log*
+.env
+.yarn

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,10 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "dart-travel",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "echo \"No tests configured\""
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "three": "^0.161.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/react": "^18.0.0",
+    "@types/three": "^0.161.0",
+    "eslint": "^8.0.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,22 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  width: 100%;
+  font-family: 'Inter', sans-serif;
+  background: radial-gradient(circle at top left, #0f2027, #203a43, #2c5364);
+  color: #fff;
+}
+
+#root, body, html {
+  height: 100%;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+* {
+  box-sizing: border-box;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Dart Travel Planner',
+  description: 'Throw a dart at the globe to plan your next trip'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import { useState } from 'react';
+import Globe from '@/components/Globe';
+import { generateTravelPlan, TravelPlan } from '@/lib/travel';
+
+export default function Page() {
+  const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
+  const [budget, setBudget] = useState(1500);
+  const [plan, setPlan] = useState<TravelPlan[] | null>(null);
+
+  const handleSelect = (c: { lat: number; lon: number }) => {
+    setCoords(c);
+    setPlan(null);
+  };
+
+  const handleGenerate = () => {
+    if (coords) {
+      setPlan(generateTravelPlan(coords, budget));
+    }
+  };
+
+  return (
+    <main style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+      <div style={{ flex: 1, position: 'relative' }}>
+        <Globe onSelect={handleSelect} />
+        <div
+          style={{
+            position: 'absolute',
+            top: 20,
+            left: 20,
+            background: 'rgba(0,0,0,0.5)',
+            padding: '1rem',
+            borderRadius: '8px'
+          }}
+        >
+          <div>
+            <label>
+              Budget: $
+              <input
+                type="number"
+                value={budget}
+                onChange={(e) => setBudget(parseInt(e.target.value, 10))}
+                style={{ width: '6rem', marginLeft: '0.5rem' }}
+              />
+            </label>
+          </div>
+          {coords && (
+            <div>
+              Selected: {coords.lat.toFixed(2)}, {coords.lon.toFixed(2)}
+            </div>
+          )}
+          <button
+            onClick={handleGenerate}
+            style={{
+              marginTop: '0.5rem',
+              padding: '0.5rem 1rem',
+              background: '#ff5722',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              color: '#fff'
+            }}
+          >
+            Generate Plan
+          </button>
+        </div>
+      </div>
+      {plan && (
+        <div
+          style={{
+            maxHeight: '40vh',
+            overflowY: 'auto',
+            padding: '1rem',
+            background: 'rgba(0,0,0,0.6)'
+          }}
+        >
+          <h2>Travel Plan</h2>
+          <ul>
+            {plan.map((item) => (
+              <li key={item.day}>
+                Day {item.day}: {item.activity}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/src/components/Globe.tsx
+++ b/src/components/Globe.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import * as THREE from 'three';
+import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls';
+
+interface Props {
+  onSelect: (coords: { lat: number; lon: number }) => void;
+}
+
+export default function Globe({ onSelect }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const dartRef = useRef<THREE.Mesh>();
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const width = containerRef.current.clientWidth;
+    const height = containerRef.current.clientHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 1000);
+    camera.position.set(0, 0, 3);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setSize(width, height);
+    containerRef.current.appendChild(renderer.domElement);
+
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.enableDamping = true;
+
+    const texture = new THREE.TextureLoader().load(
+      'https://cdn.jsdelivr.net/gh/hustcc/earth-map@master/world.jpg'
+    );
+    const geometry = new THREE.SphereGeometry(1, 64, 64);
+    const material = new THREE.MeshBasicMaterial({ map: texture });
+    const globe = new THREE.Mesh(geometry, material);
+    scene.add(globe);
+
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
+    function onClick(event: MouseEvent) {
+      const rect = renderer.domElement.getBoundingClientRect();
+      mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObject(globe);
+      if (intersects.length > 0) {
+        const p = intersects[0].point.clone();
+        const radius = 1;
+        const phi = Math.acos(p.y / radius);
+        const theta = Math.atan2(p.x, p.z);
+        const lat = 90 - (phi * 180) / Math.PI;
+        const lon = ((theta * 180) / Math.PI + 180) % 360 - 180;
+        if (dartRef.current) scene.remove(dartRef.current);
+        const dartGeom = new THREE.ConeGeometry(0.02, 0.1, 8);
+        const dartMat = new THREE.MeshBasicMaterial({ color: 0xff0000 });
+        const dart = new THREE.Mesh(dartGeom, dartMat);
+        dart.position.copy(p);
+        dart.lookAt(p.clone().multiplyScalar(2));
+        scene.add(dart);
+        dartRef.current = dart;
+        onSelect({ lat, lon });
+      }
+    }
+
+    renderer.domElement.addEventListener('click', onClick);
+
+    function onResize() {
+      if (!containerRef.current) return;
+      const w = containerRef.current.clientWidth;
+      const h = containerRef.current.clientHeight;
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    }
+
+    window.addEventListener('resize', onResize);
+
+    const animate = () => {
+      requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      renderer.domElement.removeEventListener('click', onClick);
+      window.removeEventListener('resize', onResize);
+      containerRef.current?.removeChild(renderer.domElement);
+    };
+  }, [onSelect]);
+
+  return <div ref={containerRef} style={{ width: '100%', height: '100%' }} />;
+}

--- a/src/lib/travel.ts
+++ b/src/lib/travel.ts
@@ -1,0 +1,19 @@
+export interface TravelPlan {
+  day: number;
+  activity: string;
+}
+
+export function generateTravelPlan(
+  location: { lat: number; lon: number },
+  budget: number
+): TravelPlan[] {
+  const city = `Lat ${location.lat.toFixed(2)}, Lon ${location.lon.toFixed(2)}`;
+  const dailyBudget = budget / 5;
+  return [
+    { day: 1, activity: `Arrive in ${city}, check into a hotel (~$${dailyBudget.toFixed(0)})` },
+    { day: 2, activity: 'City tour and local cuisine tasting' },
+    { day: 3, activity: 'Outdoor adventure and sightseeing' },
+    { day: 4, activity: 'Cultural experiences and museum visits' },
+    { day: 5, activity: `Relax and shop for souvenirs within your $${dailyBudget.toFixed(0)} budget` }
+  ];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js app with TypeScript and ESLint
- render three.js globe that drops a dart where the user clicks
- generate a sample 5-day travel plan based on selected coordinates and budget

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c09e29e394832f944f2bc896219307